### PR TITLE
set minSdkVersion to 21 for rn 0.64.x

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion 21
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"


### PR DESCRIPTION
[according to the 0.64.0 changelog](https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#android-specific) react native now uses a `minSdkVersion` of 21. It seems that we have to bump the minSdkVersion of any library up to 21 as well to fix build errors

```
node_modules/react-native-actions-shortcuts/android/build/intermediates/tmp/manifest/androidTest/debug/manifestMerger8128084270234091765.xml:5:5-74 Error:
	uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-native:0.64.0] /root/.gradle/caches/transforms-2/files-2.1/fa817833c7e4d2fe76c9e2dd1ff1ff5f/jetified-react-native-0.64.0/AndroidManifest.xml as the library might be using APIs not available in 16
	Suggestion: use a compatible library with a minSdk of at most 16,
		or increase this project's minSdk version to at least 21,
		or use tools:overrideLibrary="com.facebook.react" to force usage (may lead to runtime failures)
```